### PR TITLE
Fix/enable unlearn card on click

### DIFF
--- a/frontend/pages/courses_id_learn/index.css
+++ b/frontend/pages/courses_id_learn/index.css
@@ -71,6 +71,12 @@
       }
       &.-learned{
         background: $learn-button-color;
+        .button-wrapper.-unlearn{
+          // overlay with -learn wrapper so that whole problem is clickable
+          width: 100%;
+          cursor: pointer;
+          z-index: 1001;
+        }
       }
       &.-yet-to-learn{
         .button-wrapper.-learn{


### PR DESCRIPTION
Closes #91 

I currently do not (yet) have a local test environment, but based on tests with Chrome dev tools this should work and I could not detect unintended side effects. 