### PR TITLE
Enable card reordering on newest-first sort-order

### DIFF
--- a/frontend/pages/courses_id/components/OldProblem/index.js
+++ b/frontend/pages/courses_id/components/OldProblem/index.js
@@ -146,7 +146,7 @@ class OldProblem extends React.Component {
 
   render = () => (
     this.ifNotOptimistic() ?
-      <Draggable isDragDisabled={this.props.flashcardOrder} draggableId={this.props.problem.id} index={this.props.index}>{(provided) =>
+      <Draggable draggableId={this.props.problem.id} index={this.props.index}>{(provided) =>
         <div
           className={`old-problem-wrapper ${css['old-problem']} ${this.ifChecked() ? '-checked' : '-not-checked'} ${this.ifLastChecked() ? '-last-checked' : ''}`}
           id={this.uniqueId}

--- a/frontend/pages/courses_id/index.css
+++ b/frontend/pages/courses_id/index.css
@@ -53,7 +53,7 @@
     padding-bottom: 200px;
     &.-newest-first section.problems{
       display: flex;
-      flex-direction: column-reverse;
+      flex-direction: column;
     }
   }
   section.problems, .new-problem{

--- a/frontend/pages/courses_id/index.js
+++ b/frontend/pages/courses_id/index.js
@@ -164,7 +164,7 @@ class Page_courses_id extends React.Component {
             ref={provided.innerRef}
             className="problems"
           >
-            {problems.map((problem, index) =>
+            {(!this.props.My.flashcardOrder ? problems : problems.slice(0).reverse()).map((problem, index) =>
               <OldProblem
                 key={problem._optimistic_id ? problem._optimistic_id : problem.id}
                 problem={problem}

--- a/frontend/services/injectFromOldToNewIndex.js
+++ b/frontend/services/injectFromOldToNewIndex.js
@@ -7,10 +7,11 @@ const injectFromOldToNewIndex = (array, oldIndex, newIndex, { direction }) => {
   console.log({ oldIndex, newIndex, direction });
   // If direction is reversed!
   if (direction) {
-    // oldIndex = array.length - 1 - oldIndex;
-    // newIndex = array.length - 1 - newIndex;
+     oldIndex = array.length - 1 - oldIndex;
+     newIndex = array.length - 1 - newIndex;
   }
 
+  console.log("Adjusted to direction: ", { oldIndex, newIndex, direction });
   let newArray = array.filter((x, index) => index !== oldIndex);
   const movedElement = array[oldIndex];
 


### PR DESCRIPTION
Enable reordering cards via drag and drop when sorting by newest-first, as mentioned in https://github.com/lakesare/memcode/issues/60#issuecomment-699874466 

Tested in GitPos with a fairly simple scenario (10 cards) and an imported course from the productive site (250 cards).
Performance seems good (no worse than that amount of quill editors causes on their own), but we might have to revisit how the cards are reversed in `renderOldProblemsToEdit` if larger courses show any trouble. 