### PR TITLE
Add persistent review mode ("review all")

### DIFF
--- a/backend/api/PageApi/index.js
+++ b/backend/api/PageApi/index.js
@@ -54,8 +54,9 @@ router.get('/courses/:id/review/persistent', authenticate, catchAsync(async (req
     return response.error(cantAccessError);
   }
 
+  const courseUserIsLearning = await CourseUserIsLearningModel.select.oneByCourseIdAndUserId(courseId, request.currentUser.id);
   const problems = await getProblemsByCourseId(courseId);
-  response.status(200).json({ courseUserIsLearning: null, problems });
+  response.status(200).json({ courseUserIsLearning, problems });
 }));
 
 router.get('/courses/:id/review/simulated', catchAsync(async (request, response) => {

--- a/backend/api/PageApi/index.js
+++ b/backend/api/PageApi/index.js
@@ -47,6 +47,17 @@ router.get('/courses/:id/review', authenticate, catchAsync(async (request, respo
   response.status(200).json({ courseUserIsLearning, problems });
 }));
 
+router.get('/courses/:id/review/persistent', authenticate, catchAsync(async (request, response) => {
+  const courseId = request.params['id'];
+
+  if (!(await canAccessCourse(courseId, request.currentUser))) {
+    return response.error(cantAccessError);
+  }
+
+  const problems = await getProblemsByCourseId(courseId);
+  response.status(200).json({ courseUserIsLearning: null, problems });
+}));
+
 router.get('/courses/:id/review/simulated', catchAsync(async (request, response) => {
   const courseId = request.params['id'];
 

--- a/backend/api/PageApi/index.js
+++ b/backend/api/PageApi/index.js
@@ -18,6 +18,14 @@ const getProblemsByCourseId = (courseId) =>
     .orderBy('position')
     .orderBy('createdAt', 'asc');
 
+const getLearnedProblemsByCuilId = (cuilId) =>
+  knex('problem').select('problem.*')
+    .innerJoin('problemUserIsLearning', {'problemUserIsLearning.problemId' : 'problem.id'})
+    .where({'problemUserIsLearning.courseUserIsLearningId' : cuilId})
+    .andWhere({'problemUserIsLearning.ifIgnored' : false})
+    .orderBy('problem.position', 'asc')
+    .orderBy('problem.createdAt', 'asc');
+
 router.get('/courses/:id/learn', authenticate, catchAsync(async (request, response) => {
   const courseId = request.params['id'];
 
@@ -55,7 +63,7 @@ router.get('/courses/:id/review/persistent', authenticate, catchAsync(async (req
   }
 
   const courseUserIsLearning = await CourseUserIsLearningModel.select.oneByCourseIdAndUserId(courseId, request.currentUser.id);
-  const problems = await getProblemsByCourseId(courseId);
+  const problems = await getLearnedProblemsByCuilId(courseId);
   response.status(200).json({ courseUserIsLearning, problems });
 }));
 

--- a/backend/api/ProblemUserIsLearningApi/reviewProblem.js
+++ b/backend/api/ProblemUserIsLearningApi/reviewProblem.js
@@ -21,7 +21,6 @@ const reviewProblem = auth(async (request, response) => {
       lastReviewedAt: now.format()
     })
     .returning('*'))[0];
-   console.log(updatedPuil);
   response.success(updatedPuil);
 });
 

--- a/backend/api/ProblemUserIsLearningApi/reviewProblem.js
+++ b/backend/api/ProblemUserIsLearningApi/reviewProblem.js
@@ -21,7 +21,7 @@ const reviewProblem = auth(async (request, response) => {
       lastReviewedAt: now.format()
     })
     .returning('*'))[0];
-
+   console.log(updatedPuil);
   response.success(updatedPuil);
 });
 

--- a/frontend/appComponents/CourseCardSimple/index.js
+++ b/frontend/appComponents/CourseCardSimple/index.js
@@ -14,17 +14,20 @@ class CourseCardSimple extends React.Component {
       courseCategory: PropTypes.object.isRequired,
       averageCourseRating: PropTypes.string,
     }).isRequired,
-    ifShowSimulatedReviewButton: PropTypes.bool
+    ifShowSimulatedReviewButton: PropTypes.bool,
+    ifShowPersistentReviewButton: PropTypes.bool
   }
 
   static defaultProps = {
-    ifShowSimulatedReviewButton: false
+    ifShowSimulatedReviewButton: false,
+    ifShowPersistentReviewButton: false
   }
 
   getUrl = () =>
     this.props.ifShowSimulatedReviewButton ?
       Urls.courseReviewSimulated(this.props.courseDto.course.id) :
-      Urls.courseShow(this.props.courseDto.course.id);
+      (this.props.ifShowPersistentReviewButton ? Urls.courseReviewPersistent(this.props.courseDto.course.id) : 
+      Urls.courseShow(this.props.courseDto.course.id));
 
   render = () =>
     <Link
@@ -51,7 +54,7 @@ class CourseCardSimple extends React.Component {
       }
 
       {
-        this.props.ifShowSimulatedReviewButton ?
+        this.props.ifShowSimulatedReviewButton || this.props.ifShowPersistentReviewButton ?
           <section className="total-amount-of-flashcards">
             PLAY
           </section> :

--- a/frontend/appComponents/CourseCardSimple/index.js
+++ b/frontend/appComponents/CourseCardSimple/index.js
@@ -23,11 +23,16 @@ class CourseCardSimple extends React.Component {
     ifShowPersistentReviewButton: false
   }
 
-  getUrl = () =>
-    this.props.ifShowSimulatedReviewButton ?
-      Urls.courseReviewSimulated(this.props.courseDto.course.id) :
-      (this.props.ifShowPersistentReviewButton ? Urls.courseReviewPersistent(this.props.courseDto.course.id) : 
-      Urls.courseShow(this.props.courseDto.course.id));
+  getUrl = () => {
+      if (this.props.ifShowSimulatedReviewButton) {
+          return Urls.courseReviewSimulated(this.props.courseDto.course.id)
+      } else if (this.props.ifShowPersistentReviewButton) {
+          return Urls.courseReviewPersistent(this.props.courseDto.course.id)
+      } else {
+          return Urls.courseShow(this.props.courseDto.course.id)
+      }
+  }
+
 
   render = () =>
     <Link

--- a/frontend/components/CourseActions/components/CuilButtons.js
+++ b/frontend/components/CourseActions/components/CuilButtons.js
@@ -89,6 +89,21 @@ class CuilButtons extends React.Component {
       }
 
       {
+        this.props.courseDto.amountOfProblems > 0 &&  this.ifCourseIsLearnedAndActive() &&
+        <li>
+          <Link
+            to={`/courses/${this.props.courseDto.course.id}/review/persistent`}
+            style={{ color: 'rgb(255, 165, 0)' }}
+          >
+            <div className="text">Review All</div>
+            <div className="comment -white">
+              Review all flashcards of this course with your results being recorded.
+            </div>
+          </Link>
+        </li>
+      }
+
+      {
         this.ifCourseIsLearnedAndActive() &&
         <li>
           <button

--- a/frontend/components/CourseActions/components/CuilButtons.js
+++ b/frontend/components/CourseActions/components/CuilButtons.js
@@ -74,7 +74,7 @@ class CuilButtons extends React.Component {
   renderDropdown = () =>
     <ul className="standard-tooltip-dropdown">
       {
-        this.props.courseDto.amountOfProblems > 0 &&
+        this.props.courseDto.amountOfProblems > 0 && !this.ifCourseIsLearnedAndActive() &&
         <li>
           <Link
             to={`/courses/${this.props.courseDto.course.id}/review/simulated`}
@@ -93,7 +93,7 @@ class CuilButtons extends React.Component {
         <li>
           <Link
             to={`/courses/${this.props.courseDto.course.id}/review/persistent`}
-            style={{ color: 'rgb(212, 85, 18)' }}
+            style={{ color: 'rgb(236, 236, 133)' }}
           >
             <div className="text">Review All</div>
             <div className="comment -white">

--- a/frontend/components/CourseActions/components/CuilButtons.js
+++ b/frontend/components/CourseActions/components/CuilButtons.js
@@ -93,7 +93,7 @@ class CuilButtons extends React.Component {
         <li>
           <Link
             to={`/courses/${this.props.courseDto.course.id}/review/persistent`}
-            style={{ color: 'rgb(255, 165, 0)' }}
+            style={{ color: 'rgb(212, 85, 18)' }}
           >
             <div className="text">Review All</div>
             <div className="comment -white">

--- a/frontend/pages/courses_id_review/components/ProblemBeingSolved/components/Subheader/index.css
+++ b/frontend/pages/courses_id_review/components/ProblemBeingSolved/components/Subheader/index.css
@@ -108,6 +108,24 @@
       // justify-content: space-between;
     }
   }
+   &.-persistent-review > .container{
+    padding-top: 10px;
+    padding-bottom: 10px;
+    > div.instructions{
+      &.-desktop{
+        display: flex;
+        .volume-button{
+          padding-left: 8px;
+          padding-right: 8px;
+          margin-left: 6px;
+        }
+      }
+    }
+    > div.instructions.-mobile{
+      // display: flex;
+      // justify-content: space-between;
+    }
+  }
   &.-usual-review > .container{
     > div.instructions{
       p{

--- a/frontend/pages/courses_id_review/components/ProblemBeingSolved/components/Subheader/index.js
+++ b/frontend/pages/courses_id_review/components/ProblemBeingSolved/components/Subheader/index.js
@@ -160,9 +160,11 @@ class Subheader extends React.Component {
     </section>
 
   render = () => {
-    if (!this.props.ifReviewIsSimulated && !this.props.ifReviewingFailedProblems) {
+    if (!this.props.ifReviewIsSimulated && !this.props.ifReviewIsPersistent && !this.props.ifReviewingFailedProblems) {
       return this.renderUsualReview();
-    } else if (this.props.ifReviewIsSimulated && !this.props.ifReviewingFailedProblems) {
+    } else if (this.props.ifReviewIsPersistent && !this.props.ifReviewIsSimulated && !this.props.ifReviewingFailedProblems) {
+      return this.renderPersistentReview();
+    } else if (this.props.ifReviewIsSimulated && !this.props.ifReviewIsPersistent && !this.props.ifReviewingFailedProblems) {
       return this.renderSimulatedReview();
     } else if (this.props.ifReviewingFailedProblems) {
       return this.renderFailedFlashcardsReview();

--- a/frontend/pages/courses_id_review/components/ProblemBeingSolved/components/Subheader/index.js
+++ b/frontend/pages/courses_id_review/components/ProblemBeingSolved/components/Subheader/index.js
@@ -23,6 +23,7 @@ class Subheader extends React.Component {
     switchQuestionAndAnswer: PropTypes.func.isRequired,
 
     ifReviewIsSimulated: PropTypes.bool.isRequired,
+    ifReviewIsPersistent: PropTypes.bool.isRequired,
     ifReviewingFailedProblems: PropTypes.bool.isRequired,
 
     MyActions: PropTypes.object.isRequired,
@@ -63,6 +64,22 @@ class Subheader extends React.Component {
         </div>
         <div className="instructions -mobile">
           <p><em className="yellow-emphasis">Test drive</em> - results are not recorded.</p>
+          {this.renderVolumeButton()}
+        </div>
+
+        {this.renderProgressBar(1 + this.props.statusOfSolving.index, this.props.amountOfProblems)}
+      </div>
+    </section>
+
+  renderPersistentReview = () =>
+    <section className={`Subheader ${css.section} -persistent-review`}>
+      <div className="container">
+        <div className="instructions -desktop">
+          <p><em className="review-emphasis">Review All</em> - results will be recoded. Press ENTER to reveal answers</p>
+          {this.renderVolumeButton()}
+        </div>
+        <div className="instructions -mobile">
+          <p><em className="review-emphasis">Review All</em> - results will be recorded.</p>
           {this.renderVolumeButton()}
         </div>
 

--- a/frontend/pages/courses_id_review/components/ProblemBeingSolved/index.css
+++ b/frontend/pages/courses_id_review/components/ProblemBeingSolved/index.css
@@ -176,6 +176,11 @@
         display: flex;
         justify-content: space-between;
       }
+      &.-persistent-review .instructions.-mobile{
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+      }
       position: absolute;
       bottom: 0;
       width: 100%;

--- a/frontend/pages/courses_id_review/components/ProblemBeingSolved/index.js
+++ b/frontend/pages/courses_id_review/components/ProblemBeingSolved/index.js
@@ -18,6 +18,7 @@ class ProblemBeingSolved extends React.Component {
     switchQuestionAndAnswer: PropTypes.func.isRequired,
 
     ifReviewIsSimulated: PropTypes.bool.isRequired,
+    ifReviewIsPersistent: PropTypes.bool.isRequired,
     ifReviewingFailedProblems: PropTypes.bool.isRequired,
     onRightAnswerGiven: PropTypes.func.isRequired,
   }
@@ -73,6 +74,7 @@ class ProblemBeingSolved extends React.Component {
         switchQuestionAndAnswer={this.props.switchQuestionAndAnswer}
 
         ifReviewIsSimulated={this.props.ifReviewIsSimulated}
+        ifReviewIsPersistent={this.props.ifReviewIsPersistent}
         ifReviewingFailedProblems={this.props.ifReviewingFailedProblems}
       />
 

--- a/frontend/pages/courses_id_review/duck/actions.js
+++ b/frontend/pages/courses_id_review/duck/actions.js
@@ -206,15 +206,19 @@ const enterPressedInPersistentReview = () =>
     }
   };
 
-const getPage = (courseId, ifSimulated, ifPersistent) =>
-  (dispatch) =>
+const getPage = (courseId, simulated, persistent) =>
+  (dispatch) =>{
+    var url;
+    if(simulated){
+        url =  `/api/pages/courses/${courseId}/review/simulated`;
+    } else if(persistent){
+        url = `/api/pages/courses/${courseId}/review/persistent`;
+    } else {
+        url =  `/api/pages/courses/${courseId}/review`;
+    }
     commonFetch(
       (spe) => dispatch({ type: 'SET_SPE_GET_PAGE', payload: spe }),
-      'GET',
-        ifSimulated ?
-            `/api/pages/courses/${courseId}/review/simulated` :
-            (ifPersistent ? `/api/pages/courses/${courseId}/review/persistent` : 
-            `/api/pages/courses/${courseId}/review`)
-    );
+      'GET', url);
+  }
 
 export default { enterPressed, enterPressedInSimulatedReview, enterPressedInPersistentReview, getPage };

--- a/frontend/pages/courses_id_review/duck/actions.js
+++ b/frontend/pages/courses_id_review/duck/actions.js
@@ -179,9 +179,9 @@ const enterPressedInPersistentReview = () =>
             api.ProblemUserIsLearningApi.reviewProblem(
                 false,
                 {
-                id: state.speGetPage.payload.courseUserIsLearning.id,
-                problemId: currentProblem.id,
-                performanceRating: score
+                    id: state.speGetPage.payload.courseUserIsLearning.id,
+                    problemId: currentProblem.id,
+                    performanceRating: score
                 }
             );
   

--- a/frontend/pages/courses_id_review/duck/actions.js
+++ b/frontend/pages/courses_id_review/duck/actions.js
@@ -217,4 +217,4 @@ const getPage = (courseId, ifSimulated, ifPersistent) =>
             `/api/pages/courses/${courseId}/review`)
     );
 
-export default { enterPressed, enterPressedInSimulatedReview, enterPressedInReviewAll, getPage };
+export default { enterPressed, enterPressedInSimulatedReview, enterPressedInPersistentReview, getPage };

--- a/frontend/pages/courses_id_review/index.js
+++ b/frontend/pages/courses_id_review/index.js
@@ -49,31 +49,33 @@ import actions from './duck/actions';
       My: state.global.My
     };
   },
-  (dispatch, ownProps) => ({
-    getPage: (courseId) => dispatch(
-      actions.getPage(courseId, ownProps.simulated)
-    ),
-    enterPressed: () => {
-      ownProps.simulated ?
-        dispatch(actions.enterPressedInSimulatedReview()) :
-        dispatch(actions.enterPressed());
-    },
-    separateAnswerSelfScoreGiven: (selfScore) =>
-      dispatch({
-        type: 'SEPARATE_ANSWER_SELF_SCORE_GIVEN',
-        payload: selfScore
-      }),
-    onRightAnswerGiven: () => dispatch({ type: 'INLINED_ANSWER_GIVEN' }),
-    randomizeProblems: () => dispatch({ type: 'RANDOMIZE_PROBLEMS' }),
-    switchQuestionAndAnswer: () => dispatch({ type: 'SWITCH_QUESTION_AND_ANSWER' }),
+    (dispatch, ownProps) => ({
+        getPage: (courseId) => dispatch(
+            actions.getPage(courseId, ownProps.simulated, ownProps.persistent)
+        ),
+        enterPressed: () => {
+            ownProps.simulated ?
+                dispatch(actions.enterPressedInReviewAll()) :
+                (ownProps.persistent ? dispatch(actions.enterPressedInSimulatedReview()) : 
+                dispatch(actions.enterPressed()));
+        },
+        separateAnswerSelfScoreGiven: (selfScore) =>
+            dispatch({
+                type: 'SEPARATE_ANSWER_SELF_SCORE_GIVEN',
+                payload: selfScore
+            }),
+        onRightAnswerGiven: () => dispatch({ type: 'INLINED_ANSWER_GIVEN' }),
+        randomizeProblems: () => dispatch({ type: 'RANDOMIZE_PROBLEMS' }),
+        switchQuestionAndAnswer: () => dispatch({ type: 'SWITCH_QUESTION_AND_ANSWER' }),
 
-    MyActions: dispatch(MyDuck.getActions)
-  })
+        MyActions: dispatch(MyDuck.getActions)
+    })
 )
 class Page_courses_id_review extends React.Component {
   static propTypes = {
     courseId: PropTypes.number.isRequired,
     simulated: PropTypes.bool,
+    persistent: PropTypes.bool,
     getPage: PropTypes.func.isRequired,
 
     speGetPage: PropTypes.object.isRequired,
@@ -97,7 +99,8 @@ class Page_courses_id_review extends React.Component {
   }
 
   static defaultProps = {
-    simulated: false
+    simulated: false,
+    persistent: false
   }
 
   componentDidMount() {
@@ -143,6 +146,7 @@ class Page_courses_id_review extends React.Component {
         switchQuestionAndAnswer={() => {}}
 
         ifReviewIsSimulated={this.props.simulated}
+        ifReviewIsPersistent={this.props.persistent}
         ifReviewingFailedProblems={false}
       />
     </section>;
@@ -163,6 +167,7 @@ class Page_courses_id_review extends React.Component {
         <ProblemBeingSolved
           problem={this.props.currentProblem}
           ifReviewIsSimulated={this.props.simulated}
+          ifReviewIsPersistent={this.props.persistent}
           ifReviewingFailedProblems={this.props.ifReviewingFailedProblems}
           statusOfSolving={this.props.statusOfSolving}
           amountOfProblems={this.props.amountOfProblems}

--- a/frontend/pages/courses_id_review/index.js
+++ b/frontend/pages/courses_id_review/index.js
@@ -55,7 +55,7 @@ import actions from './duck/actions';
         ),
         enterPressed: () => {
             ownProps.simulated ?
-                dispatch(actions.enterPressedInReviewAll()) :
+                dispatch(actions.enterPressedInPersistentReview()) :
                 (ownProps.persistent ? dispatch(actions.enterPressedInSimulatedReview()) : 
                 dispatch(actions.enterPressed()));
         },

--- a/frontend/pages/courses_id_review/index.js
+++ b/frontend/pages/courses_id_review/index.js
@@ -55,8 +55,8 @@ import actions from './duck/actions';
         ),
         enterPressed: () => {
             ownProps.simulated ?
-                dispatch(actions.enterPressedInPersistentReview()) :
-                (ownProps.persistent ? dispatch(actions.enterPressedInSimulatedReview()) : 
+                dispatch(actions.enterPressedInSimulatedReview()) :
+                (ownProps.persistent ? dispatch(actions.enterPressedInPersistentReview()) : 
                 dispatch(actions.enterPressed()));
         },
         separateAnswerSelfScoreGiven: (selfScore) =>

--- a/frontend/pages/courses_id_review/index.js
+++ b/frontend/pages/courses_id_review/index.js
@@ -54,10 +54,13 @@ import actions from './duck/actions';
             actions.getPage(courseId, ownProps.simulated, ownProps.persistent)
         ),
         enterPressed: () => {
-            ownProps.simulated ?
-                dispatch(actions.enterPressedInSimulatedReview()) :
-                (ownProps.persistent ? dispatch(actions.enterPressedInPersistentReview()) : 
-                dispatch(actions.enterPressed()));
+            if(ownProps.simulated){
+                dispatch(actions.enterPressedInSimulatedReview());
+            } else if (ownProps.persistent){
+                dispatch(actions.enterPressedInPersistentReview());
+            } else {
+                 dispatch(actions.enterPressed());
+            }
         },
         separateAnswerSelfScoreGiven: (selfScore) =>
             dispatch({

--- a/frontend/router.js
+++ b/frontend/router.js
@@ -36,8 +36,9 @@ const router =
       <Route exact path="/courses/new"        component={auth(Page_courses_new)}/>
       <Route exact path="/courses/:id"        component={Page_courses_id}/>
       <Route exact path="/courses/:id/learn"  component={auth(Page_courses_id_learn)}/>
-      <Route exact path="/courses/:id/review" component={auth(Page_courses_id_review)} simulated={false}/>
+      <Route exact path="/courses/:id/review" component={auth(Page_courses_id_review)} simulated={false} persistent={false}/>
       <Route exact path="/courses/:id/review/simulated" component={(props) => <Page_courses_id_review {...props} simulated/>}/>
+      <Route exact path="/courses/:id/review/persistent" component={(props) => <Page_courses_id_review {...props} persistent/>}/>
 
       <Route exact path="/profile" component={Page_profile}/>
       <Route exact path="/users/:id" component={Page_users_id}/>

--- a/frontend/services/Urls.js
+++ b/frontend/services/Urls.js
@@ -7,9 +7,10 @@ const courseShow = (id) => `/courses/${id}`;
 const courseLearn = (id) => `/courses/${id}/learn`;
 const courseReview = (id) => `/courses/${id}/review`;
 const courseReviewSimulated = (id) => `/courses/${id}/review/simulated`;
+const courseReviewPersistent = (id) => `/courses/${id}/review/persistent`;
 
 export default {
   courses,
   myCourses,
-  courseShow, courseLearn, courseReview, courseReviewSimulated
+  courseShow, courseLearn, courseReview, courseReviewSimulated, courseReviewAll
 };

--- a/frontend/services/Urls.js
+++ b/frontend/services/Urls.js
@@ -12,5 +12,5 @@ const courseReviewPersistent = (id) => `/courses/${id}/review/persistent`;
 export default {
   courses,
   myCourses,
-  courseShow, courseLearn, courseReview, courseReviewSimulated, courseReviewAll
+  courseShow, courseLearn, courseReview, courseReviewSimulated, courseReviewPersistent
 };


### PR DESCRIPTION
- Adds a new mode called "review all", as discussed in #110 
- Internally it is referred to as "persistent" where the "test drive" is referred to as "simulated"
- Review results with a score < 5 are reported to the API, all others are treated like simulated mode
- Styles borrowed from the "test drive" button (layout) as well as "review" button (color)

Closes #110