### PR TITLE
Print all cards option

### DIFF
--- a/backend/api/PageApi/getAllPage.js
+++ b/backend/api/PageApi/getAllPage.js
@@ -4,7 +4,7 @@ import courseUserIsLearningModel from '~/models/CourseUserIsLearningModel/select
 
 const cantAccessError = "Sorry, this course is private. Only the author and coauthors and can access it.";
 
-const getReviewPage = async (request, response) => {
+const getAllPage = async (request, response) => {
   const courseId = request.body['courseId'];
 
   if (!(await canAccessCourse(courseId, request.currentUser))) {
@@ -14,10 +14,10 @@ const getReviewPage = async (request, response) => {
   const courseUserIsLearning = (await knex('courseUserIsLearning')
     .where({ courseId, userId: request.currentUser.id }))[0];
 
-  const problems = await courseUserIsLearningModel.selectReview(courseUserIsLearning.id);
+  const problems = await courseUserIsLearningModel.selectAll(courseUserIsLearning.id);
   
   response.success({ courseUserIsLearning, problems });
 
 };
 
-export default getReviewPage;
+export default getAllPage;

--- a/backend/api/PageApi/index.js
+++ b/backend/api/PageApi/index.js
@@ -5,7 +5,7 @@ import knex from '~/db/knex';
 import catchAsync from '~/services/catchAsync';
 import authenticate from '~/middlewares/authenticate';
 import canAccessCourse from '~/services/canAccessCourse';
-import CourseUserIsLearningModel from '~/models/CourseUserIsLearningModel';
+import courseUserIsLearningModel from '~/models/CourseUserIsLearningModel/select/index';
 import ProblemUserIsLearningModel from '~/models/ProblemUserIsLearningModel';
 import getProblemsByCourseId from '~/api/services/getProblemsByCourseId';
 
@@ -49,7 +49,8 @@ router.get('/courses/:id/review', authenticate, catchAsync(async (request, respo
 
   const courseUserIsLearning = (await knex('courseUserIsLearning')
     .where({ courseId, userId: request.currentUser.id }))[0];
-  const problems = await CourseUserIsLearningModel.select.problemsToReview(courseUserIsLearning.id);
+  const problems = await courseUserIsLearningModel.selectReview(courseUserIsLearning.id);
+
   response.status(200).json({ courseUserIsLearning, problems });
 }));
 

--- a/backend/api/PageApi/index.js
+++ b/backend/api/PageApi/index.js
@@ -98,4 +98,7 @@ router.getUserPage = getUserPage;
 import getReviewPage from './getReviewPage';
 router.getReviewPage = getReviewPage;
 
+import getAllPage from './getAllPage';
+router.getAllPage = getAllPage;
+
 export default router;

--- a/backend/models/CourseUserIsLearningModel/select/index.js
+++ b/backend/models/CourseUserIsLearningModel/select/index.js
@@ -1,23 +1,44 @@
-import db from '~/db/init.js';
+import knex from '~/db/knex';
+import dayjs from 'dayjs';
 
-const select = {
-  problemsToReview: (cuilId) =>
-    db.any(
-      `
-      SELECT problem.*
-      FROM problem
-      INNER JOIN problem_user_is_learning
-      ON problem_user_is_learning.problem_id = problem.id
-      WHERE
-          problem_user_is_learning.course_user_is_learning_id = \${cuilId}
-        AND
-          problem_user_is_learning.next_due_date < now()
-        AND
-          problem_user_is_learning.if_ignored = false
-      ORDER BY problem.position, problem.created_at
-      `,
-      { cuilId }
-    )
+const selectReview = async(cuilId) => {
+  const now = dayjs();
+
+  return await knex('problem')
+    .select('problem.*')
+    .join('problem_user_is_learning', {
+      'problem_user_is_learning.problem_id': 'problem.id'
+    })
+    .where({ 
+      'problem_user_is_learning.course_user_is_learning_id': cuilId,
+      'problem_user_is_learning.if_ignored': false
+    })
+    .andWhere('problem_user_is_learning.next_due_date', '<', now)
+    .orderBy([ 
+      { column: 'position' },
+      { column: 'created_at' }
+    ]);
 };
 
-export default select;
+const selectAll = async(cuilId) => {
+  const now = dayjs();
+
+  return await knex('problem')
+    .select('problem.*')
+    .join('problem_user_is_learning', {
+      'problem_user_is_learning.problem_id': 'problem.id'
+    })
+    .where({ 
+      'problem_user_is_learning.course_user_is_learning_id': cuilId,
+      'problem_user_is_learning.if_ignored': false
+    })
+    .orderBy([ 
+      { column: 'position' },
+      { column: 'created_at' }
+    ]);
+};
+
+export default {
+  selectReview,
+  selectAll,
+};

--- a/frontend/components/CourseActions/components/CuilButtons.js
+++ b/frontend/components/CourseActions/components/CuilButtons.js
@@ -149,6 +149,22 @@ class CuilButtons extends React.Component {
       {
         this.ifCourseIsLearnedAndActive() &&
         <li>
+          <Link
+            to={`/courses/${this.props.courseDto.course.id}/all/print`}
+            target="_blank"
+            style={{ color: 'rgb(219, 219, 216)' }}
+          >
+            <div className="text">Print All Out</div>
+            <div className="comment -white">
+              Open a page suitable for printing all cards within this deck.
+            </div>
+          </Link>
+        </li>
+      }
+
+      {
+        this.ifCourseIsLearnedAndActive() &&
+        <li>
           <button
             type="button"
             onClick={this.props.apiStopLearning}

--- a/frontend/pages/courses_id_all_print/index.css
+++ b/frontend/pages/courses_id_all_print/index.css
@@ -1,0 +1,54 @@
+:local(.main){
+  background: white;
+  padding-bottom: 60px;
+  header, footer{
+    display: none !important;
+  }
+  section.course-actions{
+    .title-and-buttons{
+      background: white;
+    }
+    .title{
+      color: black;
+      font-family: 'Open Sans';
+    }
+    .buttons{
+      display: none !important;
+    }
+  }
+  div.problem-wrapper{
+    max-width: 1210px;
+    margin: 0 auto;
+    margin-bottom: 20px; margin-top: 60px;
+    position: relative;
+    .index{
+      color: rgb(130, 130, 130);
+      position: absolute;
+      top: 11px;
+      left: 11px;
+      background: rgb(240, 240, 240);
+      width: 20px;
+      height: 20px;
+      border-radius: 2px;
+      text-align: center;
+      font-size: 12px;
+      font-weight: bold;
+      padding-top: 3px;
+      z-index: 10000;
+    }
+    section.problem{
+      box-shadow: 0px 0px 32px 4px rgba(224, 174, 234, 0.08);
+      padding: 18px;
+      border-radius: 5px;
+
+      .quill{
+        height: 100%;
+        .ql-editor{
+          line-height: 28px;
+          font-size: 16px;
+          border: 2px solid rgba(240, 240, 240, 0.9) !important;
+        }
+      }
+    }
+  }
+}

--- a/frontend/pages/courses_id_all_print/index.js
+++ b/frontend/pages/courses_id_all_print/index.js
@@ -1,0 +1,83 @@
+import orFalse from '~/services/orFalse';
+
+import Main from '~/appComponents/Main';
+import Loading from '~/components/Loading';
+import CourseActions from '~/components/CourseActions';
+import Problem from '~/components/Problem';
+
+import css from './index.css';
+import MyDuck from '~/ducks/MyDuck';
+
+import api from '~/api';
+
+@connect(
+  (state, ownProps) => {
+    const pageState = state.pages.Page_courses_id_review;
+    return {
+      courseId: Number.parseInt(ownProps.match.params.id),
+      currentUser: state.global.Authentication.currentUser || false,
+      ...pageState.speGetPage.status === 'success' &&
+        {
+          statusOfSolving:  pageState.statusOfSolving,
+          amountOfProblems: pageState.speGetPage.payload.problems.length
+        },
+      amountOfFailedProblems: pageState.amountOfFailedProblems,
+      amountOfFailedProblemsLeft: pageState.indexesOfFailedProblems.length,
+
+      My: state.global.My
+    };
+  },
+  (dispatch) => ({
+    MyActions: dispatch(MyDuck.getActions)
+  })
+)
+class Page_courses_id_all extends React.Component {
+  static propTypes = {
+    courseId: PropTypes.number.isRequired,
+    currentUser: orFalse(PropTypes.object).isRequired,
+
+    MyActions: PropTypes.object.isRequired,
+    My: PropTypes.object.isRequired
+  }
+
+  state = {
+    speGetPage: {}
+  }
+
+  componentDidMount = () => {
+    api.PageApi.getAllPage(
+      (spe) => this.setState({ speGetPage: spe }),
+      { courseId: this.props.courseId }
+    );
+    this.props.MyActions.apiGetCourseForActions(this.props.courseId);
+  }
+
+  render = () =>
+    <Main className={`${css.main} -bright-theme`}>
+      <CourseActions
+        courseId={this.props.courseId}
+        currentUser={this.props.currentUser}
+        type="review"
+        My={this.props.My}
+        MyActions={this.props.MyActions}
+      />
+
+      <Loading spe={this.state.speGetPage}>{({ problems }) =>
+        <div className="container">{
+          problems.map((problem, index) =>
+            <div className="problem-wrapper">
+              <div className="index">{index + 1}</div>
+              <Problem
+                key={problem.id}
+                mode="show"
+                problemContent={problem.content}
+                problemType={problem.type}
+              />
+            </div>
+          )
+        }</div>
+      }</Loading>
+    </Main>
+}
+
+export default Page_courses_id_all;

--- a/frontend/router.js
+++ b/frontend/router.js
@@ -5,6 +5,7 @@ import onEnters from '~/services/onEnters';
 import Page_courses from './pages/courses';
 import Page_courses_new from './pages/courses_new';
 import Page_courses_id_review_print from './pages/courses_id_review_print';
+import Page_courses_id_all_print from './pages/courses_id_all_print';
 import Page_courses_id_review from './pages/courses_id_review';
 import Page_courses_id_learn from './pages/courses_id_learn';
 import Page_courses_id from './pages/courses_id';
@@ -38,6 +39,7 @@ const router =
       <Route exact path="/courses/:id/learn"  component={auth(Page_courses_id_learn)}/>
       <Route exact path="/courses/:id/review" component={auth(Page_courses_id_review)} simulated={false} persistent={false}/>
       <Route exact path="/courses/:id/review/print" component={auth(Page_courses_id_review_print)}/>
+      <Route exact path="/courses/:id/all/print" component={auth(Page_courses_id_all_print)}/>
       <Route exact path="/courses/:id/review/simulated" component={(props) => <Page_courses_id_review {...props} simulated/>}/>
       <Route exact path="/courses/:id/review/persistent" component={(props) => <Page_courses_id_review {...props} persistent/>}/>
 


### PR DESCRIPTION
A new option for printing all cards on desk was added. I also refactored the existing select in CourseUserIsLearningModel stuff to use knex instead of the old way. The rest of stuff in CourseUserIsLearningModel is still un-knexed (it doesn't seem to be used anywhere, though).

However, having two separate routes for each option results in a bit of code duplication. I'd suggest refactoring it to use only one route `/courses/:id/print` and send a boolean in the request to decide whether to retrieve only review or all flashcards. Any other suggestions appreciated.

