### PR TITLE
Fix pasting bullet and ordered lists from Word into Memcode editor

### DIFF
--- a/frontend/components/Editor/index.js
+++ b/frontend/components/Editor/index.js
@@ -1,5 +1,6 @@
 import standardToolbarContainer from '~/services/quill/standardToolbarContainer';
 import dropOrPasteImageHandler from '~/services/quill/handlers/dropOrPasteImageHandler';
+import msWordPasteMatchers     from '~/services/quill/msWordPasteMatchers';
 import uploadImageHandler      from '~/services/quill/handlers/uploadImageHandler';
 import markAsAnswerHandler     from '~/services/quill/handlers/markAsAnswerHandler';
 import codeBlockHandler        from '~/services/quill/handlers/codeBlockHandler';
@@ -72,6 +73,10 @@ const bindings = {
     shiftKey: true,
     handler: formulaHandler
   },
+
+  clipboard: {
+    matchers: msWordPasteMatchers
+  }
 
   // blurOnEsc: {
   //   key: 'Escape',

--- a/frontend/components/Editor/index.js
+++ b/frontend/components/Editor/index.js
@@ -74,10 +74,6 @@ const bindings = {
     handler: formulaHandler
   },
 
-  clipboard: {
-    matchers: msWordPasteMatchers
-  }
-
   // blurOnEsc: {
   //   key: 'Escape',
   //   handler: () => {
@@ -213,8 +209,12 @@ class Editor extends React.Component {
       bindings
     },
 
-    // https://github.com/zenoamaro/react-quill/issues/250
-    clipboard: { matchVisual: false },
+    clipboard: {
+      // https://github.com/zenoamaro/react-quill/issues/250
+      matchVisual: false,
+      // https://github.com/lakesare/memcode/pull/163
+      matchers: msWordPasteMatchers
+    },
     imageResize: {
       modules: ['Resize']
     },

--- a/frontend/services/quill/msWordPasteMatchers.js
+++ b/frontend/services/quill/msWordPasteMatchers.js
@@ -1,0 +1,52 @@
+// See https://github.com/quilljs/quill/issues/1225#issuecomment-1000785590
+
+import Delta from 'quill-delta';
+
+function matchMsWordList(node, delta) {
+    // Clone the operations
+    let ops = delta.ops.map((op) => Object.assign({}, op));
+
+    // Trim the front of the first op to remove the bullet/number
+    let bulletOp = ops.find((op) => op.insert && op.insert.trim().length);
+    if (!bulletOp) { return delta }
+
+    bulletOp.insert = bulletOp.insert.trimLeft();
+    let listPrefix = bulletOp.insert.match(/^.*?(^·|\.)/) || bulletOp.insert[0];
+    bulletOp.insert = bulletOp.insert.substring(listPrefix[0].length, bulletOp.insert.length);
+
+    // Trim the newline off the last op
+    let last = ops[ops.length-1];
+    last.insert = last.insert.substring(0, last.insert.length - 1);
+
+    // Determine the list type
+    let listType = listPrefix[0].length === 1 ? 'bullet' : 'ordered';
+
+    // Determine the list indent
+    let style = node.getAttribute('style').replace(/\n+/g, '');
+    let levelMatch = style.match(/level(\d+)/);
+    let indent = levelMatch ? levelMatch[1] - 1 : 0;
+
+    // Add the list attribute
+    ops.push({insert: '\n', attributes: {list: listType, indent}})
+
+    return new Delta(ops);
+}
+
+function maybeMatchMsWordList(node, delta) {
+    if (delta.ops[0].insert.trimLeft()[0] === '·') {
+        return matchMsWordList(node, delta);
+    }
+
+    return delta;
+}
+
+const msWordPasteMatchers = [
+    ['p.MsoListParagraphCxSpFirst', matchMsWordList],
+    ['p.MsoListParagraphCxSpMiddle', matchMsWordList],
+    ['p.MsoListParagraphCxSpLast', matchMsWordList],
+    ['p.MsoListParagraph', matchMsWordList],
+    ['p.msolistparagraph', matchMsWordList],
+    ['p.MsoNormal', maybeMatchMsWordList]
+];
+
+export default msWordPasteMatchers;


### PR DESCRIPTION
The default quill paste handling does not handle lists copied from MS Word. 

There is an open issue at quill (which is unlikely to get fixed due to Quill's project status), in the comments a reasonably solid paste handler is discussed: https://github.com/quilljs/quill/issues/1225#issuecomment-1000785590 

**Note**: Currently my GitPod is erroring out on npm install, so I cannot test what I produced. It would be great if someone can test if it actually is set up correctly.
The paste matcher works as intended as far as I can tell, and can be tested here: https://codepen.io/darshak434/pen/GRMjvwr?editors=1111