### PR TITLE
Fix non breaking spaces when pasting lists

### DIFF
--- a/frontend/services/quill/msWordPasteMatchers.js
+++ b/frontend/services/quill/msWordPasteMatchers.js
@@ -12,7 +12,7 @@ function matchMsWordList(node, delta) {
 
     bulletOp.insert = bulletOp.insert.trimLeft();
     let listPrefix = bulletOp.insert.match(/^.*?(^·|\.)/) || bulletOp.insert[0];
-    bulletOp.insert = bulletOp.insert.substring(listPrefix[0].length, bulletOp.insert.length);
+    bulletOp.insert = bulletOp.insert.substring(listPrefix[0].length, bulletOp.insert.length).trimLeft();
 
     // Trim the newline off the last op
     let last = ops[ops.length-1];


### PR DESCRIPTION
When pasting lists from word the pastematcher accidentally generated non breaking spaces between <li> and the the first character in the line.
trimLeft() on line 15 fixes this.

Intentional spaces before the first character will also be trimmed (I see no way to differentiate), however this should be a super-rare occurrence when pasting from word, and can still be fixed in the text editor after pasting.

See https://github.com/quilljs/quill/issues/1225#issuecomment-992867278